### PR TITLE
ソート機能の実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+test:
+	gotest ./... -count=1
+
+testv:
+	gotest ./... -v -count=1

--- a/cmd/enum.go
+++ b/cmd/enum.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// ref: https://github.com/spf13/pflag/issues/236#issuecomment-931600452
+type enum struct {
+	Allowed []string
+	Value   string
+}
+
+func NewEnum(allowed []string, defaultValue string) *enum {
+	return &enum{
+		Allowed: allowed,
+		Value:   defaultValue,
+	}
+}
+
+// Set implements pflag.Value.
+func (e *enum) Set(s string) error {
+	for _, v := range e.Allowed {
+		if v == s {
+			e.Value = s
+			return nil
+		}
+	}
+	return fmt.Errorf("%s is not in [%s]", s, strings.Join(e.Allowed, ","))
+}
+
+// String implements pflag.Value.
+func (e *enum) String() string {
+	return e.Value
+}
+
+// Type implements pflag.Value.
+func (e *enum) Type() string {
+	return "string"
+}
+
+var _ pflag.Value = (*enum)(nil)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,7 +6,9 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/Joju-Matsumoto/vscode-workspace/vscodeworkspace"
 	"github.com/spf13/cobra"
 )
 
@@ -20,13 +22,22 @@ var listCmd = &cobra.Command{
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		wss, err := usecase.ListWorkspace()
+
+		sortBy, err := cmd.Flags().GetString("sort")
+		if err != nil {
+			return err
+		}
+
+		wss, err := usecase.ListWorkspace(vscodeworkspace.ListWorkspaceUsecaseOption{
+			SortBy: sortBy,
+		})
 		if err != nil {
 			return err
 		}
 
 		if len(wss) == 0 {
 			fmt.Fprintln(os.Stdout, "No workspace found")
+			return nil
 		}
 
 		ShowWorkspaces(wss...)
@@ -37,13 +48,6 @@ var listCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(listCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// listCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// listCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	sortBy := NewEnum([]string{"name", "opened_at", "count"}, "opened_at")
+	listCmd.Flags().VarP(sortBy, "sort", "s", fmt.Sprintf("sort by [%s]", strings.Join(sortBy.Allowed, ",")))
 }

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Joju-Matsumoto/vscode-workspace/vscodeworkspace"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +21,7 @@ var openCmd = &cobra.Command{
 		if len(args) >= 1 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		wss, err := usecase.ListWorkspace()
+		wss, err := usecase.ListWorkspace(vscodeworkspace.ListWorkspaceUsecaseOption{})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return nil, cobra.ShellCompDirectiveError

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Joju-Matsumoto/vscode-workspace/vscodeworkspace"
 	"github.com/spf13/cobra"
 )
 
@@ -18,7 +19,7 @@ var removeCmd = &cobra.Command{
 	Long:    `remove workspace from the list`,
 	Args:    cobra.MinimumNArgs(1),
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		wss, err := usecase.ListWorkspace()
+		wss, err := usecase.ListWorkspace(vscodeworkspace.ListWorkspaceUsecaseOption{})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return nil, cobra.ShellCompDirectiveError

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Joju-Matsumoto/vscode-workspace/vscodeworkspace"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +22,7 @@ var renameCmd = &cobra.Command{
 		if len(args) >= 1 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		wss, err := usecase.ListWorkspace()
+		wss, err := usecase.ListWorkspace(vscodeworkspace.ListWorkspaceUsecaseOption{})
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return nil, cobra.ShellCompDirectiveError

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -31,6 +31,8 @@ var searchCmd = &cobra.Command{
 			workspaces = append(workspaces, wss...)
 		}
 
+		// TODO: COUNTが表示されるのが微妙
+		// TODO: 既にリポジトリに登録済みのものかどうか判定して表示を分けたい
 		ShowWorkspaces(workspaces...)
 
 		return nil

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -10,8 +10,9 @@ import (
 
 func ShowWorkspaces(wss ...vscodeworkspace.Workspace) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(w, "\033[00mNAME\033[0m\tCOUNT\tPATH\n")
 	for _, ws := range wss {
-		fmt.Fprintf(w, "\033[36m%s\033[0m\t%s\n", ws.Name, ws.Path)
+		fmt.Fprintf(w, "\033[36m%s\033[0m\t%5d\t%s\n", ws.Name, ws.Count, ws.Path)
 	}
 	w.Flush()
 }

--- a/vscodeworkspace/usecase.go
+++ b/vscodeworkspace/usecase.go
@@ -192,7 +192,16 @@ func (u *usecase) OpenWorkspace(name string) error {
 		return err
 	}
 
-	return u.executer.Open(ws.Path)
+	if err := u.executer.Open(ws.Path); err != nil {
+		return err
+	}
+
+	ws.Open()
+
+	if err := u.repository.Save(ws); err != nil {
+		return err
+	}
+	return nil
 }
 
 var _ Usecase = (*usecase)(nil)

--- a/vscodeworkspace/usecase.go
+++ b/vscodeworkspace/usecase.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sort"
 )
 
 var (
@@ -28,8 +27,12 @@ type (
 		GetWorkspace(name string) (Workspace, error)
 	}
 
+	ListWorkspaceUsecaseOption struct {
+		SortBy string // default: name
+	}
+
 	ListWorkspaceUsecase interface {
-		ListWorkspace() ([]Workspace, error)
+		ListWorkspace(opt ListWorkspaceUsecaseOption) ([]Workspace, error)
 	}
 
 	AddWorkspaceUsecase interface {
@@ -45,7 +48,7 @@ type (
 	}
 
 	SearchWorkspaceUsecase interface {
-		SearchWorkspace(query string) ([]Workspace, error)
+		SearchWorkspace(query string, opt ListWorkspaceUsecaseOption) ([]Workspace, error)
 	}
 
 	SearchWorkspaceFromDirectoryUsecase interface {
@@ -101,13 +104,13 @@ func (u *usecase) AddWorkspace(name string, path string) error {
 }
 
 // ListWorkspace implements Usecase.
-func (u *usecase) ListWorkspace() ([]Workspace, error) {
-	wss, err := u.repository.List()
+func (u *usecase) ListWorkspace(opt ListWorkspaceUsecaseOption) ([]Workspace, error) {
+	wss, err := u.repository.List(ListWorkspaceRepositoryOption{
+		SortBy: opt.GetSortBy(),
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	sort.Slice(wss, func(i, j int) bool { return wss[i].Name < wss[j].Name })
 
 	return wss, nil
 }
@@ -154,8 +157,10 @@ func (u *usecase) DeleteWorkspace(name string) error {
 }
 
 // SearchWorkspace implements Usecase.
-func (u *usecase) SearchWorkspace(query string) ([]Workspace, error) {
-	return u.repository.Search(query)
+func (u *usecase) SearchWorkspace(query string, opt ListWorkspaceUsecaseOption) ([]Workspace, error) {
+	return u.repository.Search(query, ListWorkspaceRepositoryOption{
+		SortBy: opt.GetSortBy(),
+	})
 }
 
 // SearchWorkspaceFromDirectory implements Usecase.
@@ -205,3 +210,13 @@ func (u *usecase) OpenWorkspace(name string) error {
 }
 
 var _ Usecase = (*usecase)(nil)
+
+func (opt *ListWorkspaceUsecaseOption) GetSortBy() SortBy {
+	switch opt.SortBy {
+	case "opened_at":
+		return SORTBY_OPENEDAT
+	case "count":
+		return SORTBY_COUNT
+	}
+	return SORTBY_NAME
+}

--- a/vscodeworkspace/workspace.go
+++ b/vscodeworkspace/workspace.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 var (
@@ -11,8 +12,15 @@ var (
 )
 
 type Workspace struct {
-	Name string `json:"name"`
-	Path string `json:"path"`
+	Name     string    `json:"name"`
+	Path     string    `json:"path"`
+	OpenedAt time.Time `json:"opened_at"`
+	Count    int       `json:"count"`
+}
+
+func (w *Workspace) Open() {
+	w.OpenedAt = time.Now()
+	w.Count += 1
 }
 
 func NewWorkspace(name string, path string) (Workspace, error) {
@@ -24,8 +32,9 @@ func NewWorkspace(name string, path string) (Workspace, error) {
 		name = strings.TrimSuffix(filepath.Base(path), WorkspaceFileExt)
 	}
 	ws := Workspace{
-		Name: name,
-		Path: abs,
+		Name:  name,
+		Path:  abs,
+		Count: 0,
 	}
 	if err := ws.Validate(); err != nil {
 		return Workspace{}, err


### PR DESCRIPTION
close #1 

- listコマンドのフラグに `--sort` を追加し、ワークスペースの並べ替えを可能にした
- ワークスペース名、最後にopenした日時、openした回数での並べ替えが可能
- デフォルトは最後にopenした日時順